### PR TITLE
fix(debian12): allow to override python executable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,6 +36,7 @@ remoteSyslog:
   protocol: tcp
 logrotate_policy: "daily"
 
+debian10cis_python_executable: python
 
 # Section 5 Settings
 # 5.2.18 Ensure SSH access is limited

--- a/tasks/all_mounts_facts.yaml
+++ b/tasks/all_mounts_facts.yaml
@@ -3,7 +3,7 @@
 - name: Gather facts of all mounts, including non-disk mounts
   script: facts/all_mounts.py
   args:
-    executable: python
+    executable: "{{ debian10cis_python_executable }}"
   changed_when: false
   check_mode: false
   register: all_mounts


### PR DESCRIPTION
Python in no longer available in debian12, only python3 is.